### PR TITLE
Adding typings to package copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Made Preflight similar to a PR status check, showing ✅ , ⚠️, or ❌ based on this criteria [link:criteria write-up when available]
 - Promoted our permissions experiment to a "permanent" feature that is always on
 - When viewing a file in GitHub, we now mark lines that are related to a permission as well as issues
+- Added toggle for including @types definitions in for typescript projects with types defined in DefinitelyTyped
 
 ## [1.14.0] - 2018-11-27
 

--- a/src/api/package.tsx
+++ b/src/api/package.tsx
@@ -24,12 +24,19 @@ export interface PackageEntry {
   registry: string;
   package_rank: number;
   rank_description: string;
+  types: TypesResponse | null;
 }
 
 export interface PackageResponse {
   gitUrl: string;
   packages: PackageEntry[];
   override: OverrideEntry | null;
+}
+
+export interface TypesResponse {
+  package_name: string;
+  source: string;
+  package_url: string;
 }
 
 export type OverrideType = "blacklist" | "whitelist" | "promote";

--- a/src/content/headsup/PackageCopyBox.css
+++ b/src/content/headsup/PackageCopyBox.css
@@ -11,7 +11,8 @@
   align-items: center;
 }
 
-.package-copy-box .package-action-description h2 {
+.package-copy-box .package-action-description span,
+.package-copy-box .package-action-description .package-install-action-includes {
   font-size: 14px;
   font-weight: 600;
 }
@@ -40,6 +41,7 @@
 .package-copy-box .package-npm-field input {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
     monospace;
+  font-size: 12px;
 }
 
 .package-copy-box .package-npm-field .bp3-input {

--- a/src/content/headsup/PackageCopyBox.css
+++ b/src/content/headsup/PackageCopyBox.css
@@ -32,13 +32,6 @@
   font-size: 12px;
 }
 
-.package-copy-box header .package-include-type-command {
-  position: absolute;
-  right: 65px;
-  top: 0;
-  font-size: 12px;
-}
-
 .package-endorsers .package-endorser {
   margin-right: 3px;
 }

--- a/src/content/headsup/PackageCopyBox.css
+++ b/src/content/headsup/PackageCopyBox.css
@@ -36,6 +36,10 @@
   margin-right: 3px;
 }
 
+.package-copy-box .nutrition-section-value {
+  margin-top: 3px;
+}
+
 .package-copy-box .package-npm-field,
 .package-copy-box .package-npm-field input {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,

--- a/src/content/headsup/PackageCopyBox.css
+++ b/src/content/headsup/PackageCopyBox.css
@@ -11,7 +11,7 @@
   align-items: center;
 }
 
-.package-copy-box .package-action-description span,
+.package-copy-box .package-action-description h2,
 .package-copy-box .package-action-description .package-install-action-includes {
   font-size: 14px;
   font-weight: 600;

--- a/src/content/headsup/PackageCopyBox.css
+++ b/src/content/headsup/PackageCopyBox.css
@@ -11,8 +11,7 @@
   align-items: center;
 }
 
-.package-copy-box .package-action-description h2,
-.package-copy-box .package-action-description .package-install-action-includes {
+.package-copy-box .package-action-description h2 {
   font-size: 14px;
   font-weight: 600;
 }
@@ -29,6 +28,13 @@
 .package-copy-box header .package-registry-toggle {
   position: absolute;
   right: 10px;
+  top: 0;
+  font-size: 12px;
+}
+
+.package-copy-box header .package-include-type-command {
+  position: absolute;
+  right: 65px;
   top: 0;
   font-size: 12px;
 }

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -44,7 +44,7 @@ interface PackageCopyBoxProps {
   onChangePackageManager(
     newManager: PackageManagerChoice
   ): React.MouseEventHandler<HTMLElement>;
-  onChangeTypesInclusion(
+  onChangeIncludeTypes(
     includeTypesCommand: boolean
   ): React.MouseEventHandler<HTMLElement>;
 }
@@ -61,7 +61,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
       packageManager,
       includeTypesCommand,
       onChangePackageManager,
-      onChangeTypesInclusion
+      onChangeIncludeTypes
     } = this.props;
 
     const typesFound: boolean =
@@ -79,7 +79,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                 <a
                   onClick={l(
                     "include-types-command",
-                    onChangeTypesInclusion(!includeTypesCommand),
+                    onChangeIncludeTypes(!includeTypesCommand),
                     { includeTypesCommand: includeTypesCommand }
                   )}
                   role="button"
@@ -336,7 +336,7 @@ export default class WrappedPackageCopyBox extends React.Component<
   WrappedPackageCopyBoxState
 > {
   public DEFAULT_PACKAGE_MANAGER: PackageManagerChoice = "npm";
-  public DEFAULT_TYPES_INCLUSION: boolean = true;
+  public DEFAULT_INCLUDE_TYPES: boolean = true;
 
   public constructor(props: WrappedPackageCopyBoxProps) {
     super(props);
@@ -348,13 +348,13 @@ export default class WrappedPackageCopyBox extends React.Component<
       includeTypesCommand:
         props.includeTypesCommand != null
           ? props.includeTypesCommand
-          : this.DEFAULT_TYPES_INCLUSION
+          : this.DEFAULT_INCLUDE_TYPES
     };
   }
 
   public componentDidMount() {
     this.fetchPreferredPackageManager();
-    this.fetchTypesInclusionPreference();
+    this.fetchIncludeTypesPreference();
     // Race condition may cause data to be loaded already, so we need to set
     // defaults on both mount and update
     this.setDefaultSelectedPackage();
@@ -411,7 +411,7 @@ export default class WrappedPackageCopyBox extends React.Component<
           includeTypesCommand={includeTypesCommand}
           onSelectPackage={this.handlePackageSelect}
           onChangePackageManager={this.handlePackageManagerChange}
-          onChangeTypesInclusion={this.handleEnabledChange}
+          onChangeIncludeTypes={this.handleEnabledChange}
         />
       );
     }
@@ -426,7 +426,7 @@ export default class WrappedPackageCopyBox extends React.Component<
     }
   };
 
-  private fetchTypesInclusionPreference = async () => {
+  private fetchIncludeTypesPreference = async () => {
     const includeTypesCommand = await getIncludeTypesPreference();
     if (includeTypesCommand != null) {
       this.setState({

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -522,13 +522,13 @@ function buildInstallCommand(
   switch (registry) {
     case "npm":
       if (includeTypesCommand) {
-        return `${cmds.npm};${typesCmds.npm}`;
+        return `${cmds.npm}; ${typesCmds.npm}`;
       }
 
       return cmds.npm;
     case "yarn":
       if (includeTypesCommand) {
-        return `${cmds.yarn};${typesCmds.yarn}`;
+        return `${cmds.yarn}; ${typesCmds.yarn}`;
       }
 
       return cmds.yarn;

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -19,10 +19,10 @@ import { MainToaster } from "@r2c/extension/content/Toaster";
 import CopyButton from "@r2c/extension/shared/CopyButton";
 import {
   buildPackageLink,
+  getIncludeTypesPreference,
   getPreferredPackageManager,
-  getTypesInclusionPreference,
-  setPreferredPackageManager,
-  setTypesInclusionPreference
+  setIncludeTypesPreference,
+  setPreferredPackageManager
 } from "@r2c/extension/utils";
 import * as classnames from "classnames";
 import * as copy from "copy-to-clipboard";
@@ -36,7 +36,7 @@ interface PackageCopyBoxProps {
   packages: PackageResponse;
   selectedPackage: PackageEntry;
   packageManager: PackageManagerChoice;
-  typesInclusion: boolean;
+  includeTypesCommand: boolean;
   onSelectPackage(
     newPackage: PackageEntry,
     event?: React.SyntheticEvent<HTMLElement>
@@ -59,7 +59,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
       packages,
       selectedPackage,
       packageManager,
-      typesInclusion,
+      includeTypesCommand,
       onChangePackageManager,
       onChangeTypesInclusion
     } = this.props;
@@ -89,12 +89,12 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
               <a
                 onClick={l(
                   "include-types-command",
-                  onChangeTypesInclusion(!typesInclusion),
-                  { typesInclusion: typesInclusion }
+                  onChangeTypesInclusion(!includeTypesCommand),
+                  { includeTypesCommand: includeTypesCommand }
                 )}
                 role="button"
               >
-                {typesInclusion ? "Exclude @types" : "Include @types"}
+                {includeTypesCommand ? "Exclude @types" : "Include @types"}
               </a>
             ) : null}
           </div>
@@ -138,7 +138,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                 value={buildInstallCommand(
                   packageManager,
                   selectedPackage.name,
-                  typesInclusion && typesFound
+                  includeTypesCommand && typesFound
                 )}
                 rightElement={
                   <CopyButton
@@ -147,7 +147,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                       this.handleCopy(
                         packageManager,
                         selectedPackage.name,
-                        typesInclusion && typesFound
+                        includeTypesCommand && typesFound
                       ),
                       {
                         packageManager: packageManager,
@@ -228,7 +228,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
   private handleCopy = (
     registry: string,
     packageName: string,
-    typesInclusion: boolean
+    includeTypes: boolean
   ) => (e: React.MouseEvent<HTMLElement>) => {
     const key = this.buildPackageFieldRefKey(registry, packageName);
     const toCopy = this.packageFieldRef[key];
@@ -237,7 +237,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
       toCopy.focus();
       toCopy.setSelectionRange(0, toCopy.value.length);
       this.copyToClipboard(
-        buildInstallCommand(registry, packageName, typesInclusion)
+        buildInstallCommand(registry, packageName, includeTypes)
       );
     }
   };
@@ -324,10 +324,10 @@ interface WrappedPackageCopyBoxProps {
   packages: PackageResponse | undefined;
   selectedPackage?: PackageEntry;
   packageManager?: PackageManagerChoice;
-  typesInclusion?: boolean;
+  includeTypesCommand?: boolean;
   onSelectPackage?(newPackage: PackageEntry): void;
   onChangePackageManager?(newManager: PackageManagerChoice): void;
-  onChangeTypesInclusion?(includeTypesCommand: boolean): void;
+  onChangeincludeTypes?(includeTypesCommand: boolean): void;
 }
 
 interface WrappedPackageCopyBoxState {
@@ -335,7 +335,7 @@ interface WrappedPackageCopyBoxState {
   selectedPackage: PackageEntry | undefined;
   controlPackageManager: boolean;
   packageManager: PackageManagerChoice;
-  typesInclusion: boolean;
+  includeTypesCommand: boolean;
 }
 
 export default class WrappedPackageCopyBox extends React.Component<
@@ -352,9 +352,9 @@ export default class WrappedPackageCopyBox extends React.Component<
       selectedPackage: props.selectedPackage || undefined,
       controlPackageManager: props.packageManager != null,
       packageManager: props.packageManager || this.DEFAULT_PACKAGE_MANAGER,
-      typesInclusion:
-        props.typesInclusion != null
-          ? props.typesInclusion
+      includeTypesCommand:
+        props.includeTypesCommand != null
+          ? props.includeTypesCommand
           : this.DEFAULT_TYPES_INCLUSION
     };
   }
@@ -390,7 +390,7 @@ export default class WrappedPackageCopyBox extends React.Component<
   public render() {
     const { packages: data, loading } = this.props;
 
-    const { selectedPackage, packageManager, typesInclusion } = this.state;
+    const { selectedPackage, packageManager, includeTypesCommand } = this.state;
     if (loading) {
       return (
         <section className={classnames("package-copy-box", Classes.SKELETON)}>
@@ -415,7 +415,7 @@ export default class WrappedPackageCopyBox extends React.Component<
           packages={data}
           selectedPackage={selectedPackage}
           packageManager={packageManager}
-          typesInclusion={typesInclusion}
+          includeTypesCommand={includeTypesCommand}
           onSelectPackage={this.handlePackageSelect}
           onChangePackageManager={this.handlePackageManagerChange}
           onChangeTypesInclusion={this.handleEnabledChange}
@@ -434,10 +434,10 @@ export default class WrappedPackageCopyBox extends React.Component<
   };
 
   private fetchTypesInclusionPreference = async () => {
-    const includeTypesCommand = await getTypesInclusionPreference();
+    const includeTypesCommand = await getIncludeTypesPreference();
     if (includeTypesCommand != null) {
       this.setState({
-        typesInclusion: includeTypesCommand
+        includeTypesCommand: includeTypesCommand
       });
     }
   };
@@ -461,8 +461,8 @@ export default class WrappedPackageCopyBox extends React.Component<
   private handleEnabledChange = (changeIncludeTypesCommand: boolean) => (
     e: React.MouseEvent<HTMLElement>
   ) => {
-    this.setState({ typesInclusion: changeIncludeTypesCommand });
-    setTypesInclusionPreference(changeIncludeTypesCommand);
+    this.setState({ includeTypesCommand: changeIncludeTypesCommand });
+    setIncludeTypesPreference(changeIncludeTypesCommand);
   };
 
   private handlePackageManagerChange = (

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -63,9 +63,9 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
       onChangeTypesInclusion
     } = this.props;
 
-    const typesPackage: string | null = selectedPackage.types
-      ? selectedPackage.types.package_name
-      : null;
+    const typesFound: boolean = selectedPackage.types
+      ? selectedPackage.types.package_name != null
+      : false;
 
     return (
       <section className="package-copy-box">
@@ -74,11 +74,9 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
             <h2>Install with {packageManager === "npm" ? "npm" : "Yarn"}</h2>
             <Checkbox
               className="package-install-action-includes"
-              checked={typesInclusion && typesPackage != null}
-              label={
-                typesPackage == null ? "No types info" : "including @types"
-              }
-              disabled={typesPackage == null}
+              checked={typesInclusion && typesFound}
+              label={!typesFound ? "No types info" : "including @types"}
+              disabled={!typesFound}
               onChange={onChangeTypesInclusion}
             />
             <p>
@@ -132,7 +130,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                 value={buildInstallCommand(
                   packageManager,
                   selectedPackage.name,
-                  typesInclusion
+                  typesInclusion && typesFound
                 )}
                 rightElement={
                   <CopyButton
@@ -141,7 +139,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                       this.handleCopy(
                         packageManager,
                         selectedPackage.name,
-                        typesInclusion
+                        typesInclusion && typesFound
                       ),
                       {
                         packageManager: packageManager,

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -45,7 +45,7 @@ interface PackageCopyBoxProps {
   onChangePackageManager(
     newManager: PackageManagerChoice
   ): React.MouseEventHandler<HTMLElement>;
-  onChangeTypesInclusion(event: React.FormEvent<HTMLInputElement>): void;
+  onChangeTypesInclusion?(event: React.FormEvent<HTMLInputElement>): void;
 }
 
 const PackageSelect = Select.ofType<PackageEntry>();
@@ -63,17 +63,22 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
       onChangeTypesInclusion
     } = this.props;
 
+    const typesPackage: string | null = selectedPackage.types
+      ? selectedPackage.types.package_name
+      : null;
+
     return (
       <section className="package-copy-box">
         <header>
           <div className="package-action-description">
-            <span>
-              Install with {packageManager === "npm" ? "npm" : "Yarn"}
-            </span>
+            <h2>Install with {packageManager === "npm" ? "npm" : "Yarn"}</h2>
             <Checkbox
               className="package-install-action-includes"
-              checked={typesInclusion}
-              label="including @types"
+              checked={typesInclusion && typesPackage != null}
+              label={
+                typesPackage == null ? "No types info" : "including @types"
+              }
+              disabled={typesPackage == null}
               onChange={onChangeTypesInclusion}
             />
             <p>
@@ -316,7 +321,7 @@ interface WrappedPackageCopyBoxProps {
   typesInclusion?: boolean;
   onSelectPackage?(newPackage: PackageEntry): void;
   onChangePackageManager?(newManager: PackageManagerChoice): void;
-  onChangeTypesInclusion?(): void;
+  onChangeTypesInclusion?(event: React.FormEvent<HTMLInputElement>): void;
 }
 
 interface WrappedPackageCopyBoxState {
@@ -448,7 +453,7 @@ export default class WrappedPackageCopyBox extends React.Component<
   };
 
   private handleEnabledChange = (e: React.FormEvent<HTMLInputElement>) => {
-    const checked: boolean = e.target.checked;
+    const checked: boolean = (e.target as HTMLInputElement).checked;
     this.setState({ typesInclusion: checked });
     setTypesInclusionPreference(checked);
   };

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -63,20 +63,19 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
       onChangeTypesInclusion
     } = this.props;
 
-    console.log("selectedPackage=", selectedPackage);
-    console.log("props typesInclusion=", typesInclusion);
-
     return (
       <section className="package-copy-box">
         <header>
           <div className="package-action-description">
-            <h2>Install with {packageManager === "npm" ? "npm" : "Yarn"}</h2>
+            <span>
+              Install with {packageManager === "npm" ? "npm" : "Yarn"}
+            </span>
             <Checkbox
+              className="package-install-action-includes"
               checked={typesInclusion}
               label="including @types"
               onChange={onChangeTypesInclusion}
             />
-
             <p>
               Save time and{" "}
               <a
@@ -152,7 +151,6 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                   packageManager,
                   selectedPackage.name
                 )}
-                small={true}
                 readOnly={true}
               />
             </div>
@@ -382,7 +380,6 @@ export default class WrappedPackageCopyBox extends React.Component<
     const { packages: data, loading } = this.props;
 
     const { selectedPackage, packageManager, typesInclusion } = this.state;
-    console.log("state.typesInclusion= ", typesInclusion);
     if (loading) {
       return (
         <section className={classnames("package-copy-box", Classes.SKELETON)}>
@@ -427,7 +424,6 @@ export default class WrappedPackageCopyBox extends React.Component<
 
   private fetchTypesInclusionPreference = async () => {
     const includeTypes = await getTypesInclusionPreference();
-    console.log("got includeTypes to be=", includeTypes);
     if (includeTypes != null) {
       this.setState({
         typesInclusion: includeTypes
@@ -453,7 +449,6 @@ export default class WrappedPackageCopyBox extends React.Component<
 
   private handleEnabledChange = (e: React.FormEvent<HTMLInputElement>) => {
     const checked: boolean = e.target.checked;
-    console.log("inside handleEnabledChange, checked=", checked);
     this.setState({ typesInclusion: checked });
     setTypesInclusionPreference(checked);
   };

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -73,29 +73,22 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
         <header>
           <div className="package-action-description">
             <h2>Install with {packageManager === "npm" ? "npm" : "Yarn"}</h2>
-            <p>
-              Save time and{" "}
-              <a
-                href="https://blog.npmjs.org/post/163723642530/crossenv-malware-on-the-npm-registry"
-                title="Information about and example of typosquatting"
-              >
-                avoid typos
-              </a>{" "}
-              using this command.
-            </p>
-          </div>
-          <div className="package-include-type-command">
             {typesFound ? (
-              <a
-                onClick={l(
-                  "include-types-command",
-                  onChangeTypesInclusion(!includeTypesCommand),
-                  { includeTypesCommand: includeTypesCommand }
-                )}
-                role="button"
-              >
-                {includeTypesCommand ? "Exclude @types" : "Include @types"}
-              </a>
+              <p>
+                Use TypeScript?{" "}
+                <a
+                  onClick={l(
+                    "include-types-command",
+                    onChangeTypesInclusion(!includeTypesCommand),
+                    { includeTypesCommand: includeTypesCommand }
+                  )}
+                  role="button"
+                >
+                  {includeTypesCommand
+                    ? "Hide @types command"
+                    : "Show @types commmand as well"}
+                </a>
+              </p>
             ) : null}
           </div>
           <div className="package-registry-toggle">

--- a/src/content/headsup/PackageCopyBox.tsx
+++ b/src/content/headsup/PackageCopyBox.tsx
@@ -75,7 +75,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
             <h2>Install with {packageManager === "npm" ? "npm" : "Yarn"}</h2>
             {typesFound ? (
               <p>
-                Use TypeScript?{" "}
+                {includeTypesCommand ? null : "Use TypeScript? "}
                 <a
                   onClick={l(
                     "include-types-command",
@@ -86,7 +86,7 @@ export class PackageCopyBox extends React.PureComponent<PackageCopyBoxProps> {
                 >
                   {includeTypesCommand
                     ? "Hide @types command"
-                    : "Show @types commmand as well"}
+                    : "Show @types command as well"}
                 </a>
               </p>
             ) : null}

--- a/src/shared/CopyButton.tsx
+++ b/src/shared/CopyButton.tsx
@@ -19,7 +19,7 @@ const Copy: React.SFC = () => (
 );
 
 const CopyButton: React.SFC<CopyButtonProps> = ({ onClick }) => (
-  <Button icon={<Copy />} minimal={true} onClick={onClick} />
+  <Button icon={<Copy />} minimal={false} onClick={onClick} />
 );
 
 export default CopyButton;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,6 +229,18 @@ export function setPreferredPackageManager(packageManager: string) {
   browser.storage.local.set({ [PREFERRED_PACKAGE_MANAGER]: packageManager });
 }
 
+const TYPES_INCLUSION_PREFERENCE = "TYPES_INCLUSION_PREFERENCE";
+export function setTypesInclusionPreference(checked: boolean) {
+  console.log("seting preference to be ", checked);
+  browser.storage.local.set({ [TYPES_INCLUSION_PREFERENCE]: checked });
+}
+
+export async function getTypesInclusionPreference(): Promise<
+  boolean | undefined
+> {
+  return fetchFromStorage<boolean>(TYPES_INCLUSION_PREFERENCE);
+}
+
 export async function getPreferredPackageManager(): Promise<
   string | undefined
 > {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,11 +230,11 @@ export function setPreferredPackageManager(packageManager: string) {
 }
 
 const TYPES_INCLUSION_PREFERENCE = "TYPES_INCLUSION_PREFERENCE";
-export function setTypesInclusionPreference(checked: boolean) {
+export function setIncludeTypesPreference(checked: boolean) {
   browser.storage.local.set({ [TYPES_INCLUSION_PREFERENCE]: checked });
 }
 
-export async function getTypesInclusionPreference(): Promise<
+export async function getIncludeTypesPreference(): Promise<
   boolean | undefined
 > {
   return fetchFromStorage<boolean>(TYPES_INCLUSION_PREFERENCE);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,15 +229,15 @@ export function setPreferredPackageManager(packageManager: string) {
   browser.storage.local.set({ [PREFERRED_PACKAGE_MANAGER]: packageManager });
 }
 
-const TYPES_INCLUSION_PREFERENCE = "TYPES_INCLUSION_PREFERENCE";
+const INCLUDE_TYPES_PREFERENCE = "INCLUDE_TYPES_PREFERENCE";
 export function setIncludeTypesPreference(checked: boolean) {
-  browser.storage.local.set({ [TYPES_INCLUSION_PREFERENCE]: checked });
+  browser.storage.local.set({ [INCLUDE_TYPES_PREFERENCE]: checked });
 }
 
 export async function getIncludeTypesPreference(): Promise<
   boolean | undefined
 > {
-  return fetchFromStorage<boolean>(TYPES_INCLUSION_PREFERENCE);
+  return fetchFromStorage<boolean>(INCLUDE_TYPES_PREFERENCE);
 }
 
 export async function getPreferredPackageManager(): Promise<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,7 +231,6 @@ export function setPreferredPackageManager(packageManager: string) {
 
 const TYPES_INCLUSION_PREFERENCE = "TYPES_INCLUSION_PREFERENCE";
 export function setTypesInclusionPreference(checked: boolean) {
-  console.log("seting preference to be ", checked);
   browser.storage.local.set({ [TYPES_INCLUSION_PREFERENCE]: checked });
 }
 


### PR DESCRIPTION
if a selected packages has  `@typings` package in DefinitelyTyped as determined by https://github.com/returntocorp/echelon-backend/pull/2205, then display it to copy field
**when long package names are including @types**
<img width="340" alt="screen shot 2018-12-06 at 9 07 26 pm" src="https://user-images.githubusercontent.com/1626382/49623341-3c32a800-f99b-11e8-9b7c-2624a1c81932.png">
**when including @types**
<img width="331" alt="screen shot 2018-12-06 at 9 07 30 pm" src="https://user-images.githubusercontent.com/1626382/49623342-3ccb3e80-f99b-11e8-8aa6-b90a275dbeba.png">
**when no @types found:**
<img width="346" alt="screen shot 2018-12-06 at 9 07 47 pm" src="https://user-images.githubusercontent.com/1626382/49623344-3d63d500-f99b-11e8-9886-f9a6745f8839.png">



